### PR TITLE
Pin dependency node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.19",
     "node-emoji": "^1.11.0",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "2.6.1"
   },
   "devDependencies": {
     "dotenv": "^10.0.0",


### PR DESCRIPTION
Let scrappy only use node-fetch v2.6.1; it seems like updating `node-fetch` tends to break scrappy.